### PR TITLE
Bring stix-generator back to compatibility with the stix2 library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'Faker',
         'lark-parser',
         'pytz',
-        'stix2'
+        'stix2 >= 3.0.0'
     ],
 
     extras_require={

--- a/stix2generator/exceptions.py
+++ b/stix2generator/exceptions.py
@@ -380,8 +380,8 @@ class GeneratableSTIXTypeNotFoundError(GenerationError):
 
         :param constraints: The constraints which failed to match any
             specification.  Must be a list of constraint values.  See
-            stix2generator.utils.random_generatable_stix_type() or
-            .is_stix_type() for more information.
+            stix2generator.utils.random_generatable_stix_type() for more
+            information.
         :param stix_version: The STIX version which the constraints were
             checked relative to
         """

--- a/stix2generator/generation/pattern_generator.py
+++ b/stix2generator/generation/pattern_generator.py
@@ -244,7 +244,7 @@ class PatternGenerator:
     def __random_sco_type(self):
         return stix2generator.utils.random_generatable_stix_type(
             self.__generator,
-            stix2generator.utils.STIXTypeClass.SCO,
+            stix2.utils.STIXTypeClass.SCO,
             stix_version=self.__stix_version
         )
 

--- a/stix2generator/generation/reference_graph_generator.py
+++ b/stix2generator/generation/reference_graph_generator.py
@@ -671,8 +671,8 @@ class ReferenceGraphGenerator:
         """
         if not seed_type:
             seed_type = self.__random_generatable_seed_type(
-                stix2generator.utils.STIXTypeClass.SDO,
-                stix2generator.utils.STIXTypeClass.SCO
+                stix2.utils.STIXTypeClass.SDO,
+                stix2.utils.STIXTypeClass.SCO
             )
         else:
             # Might seem kinda silly if seed_type is directly given as a string,

--- a/stix2generator/generation/reference_graph_generator.py
+++ b/stix2generator/generation/reference_graph_generator.py
@@ -674,8 +674,8 @@ class ReferenceGraphGenerator:
         """
         if not seed_type:
             seed_type = self.__random_generatable_seed_type(
-                stix2generator.utils.STIXTypeClass.SDO,
-                stix2generator.utils.STIXTypeClass.SCO
+                stix2.utils.STIXTypeClass.SDO,
+                stix2.utils.STIXTypeClass.SCO
             )
         else:
             # Might seem kinda silly if seed_type is directly given as a string,

--- a/stix2generator/generation/semantics.py
+++ b/stix2generator/generation/semantics.py
@@ -6,6 +6,7 @@ import uuid
 
 import pytz
 
+import stix2.utils
 import stix2generator.exceptions
 import stix2generator.generation.pattern_generator
 import stix2generator.generation.reference_graph_generator
@@ -329,7 +330,7 @@ class STIXSemantics(SemanticsProvider):
             .ReferenceGraphGenerator(generator, config)
 
         sco_type = stix2generator.utils.random_generatable_stix_type(
-            generator, stix2generator.utils.STIXTypeClass.SCO
+            generator, stix2.utils.STIXTypeClass.SCO
         )
         _, container = observable_container_generator.generate(sco_type)
 

--- a/stix2generator/generation/semantics.py
+++ b/stix2generator/generation/semantics.py
@@ -6,6 +6,7 @@ import uuid
 
 import pytz
 
+import stix2.utils
 import stix2generator.exceptions
 import stix2generator.generation.pattern_generator
 import stix2generator.generation.reference_graph_generator

--- a/stix2generator/generation/semantics.py
+++ b/stix2generator/generation/semantics.py
@@ -341,7 +341,7 @@ class STIXSemantics(SemanticsProvider):
             .ReferenceGraphGenerator(generator, config)
 
         _, container = observable_container_generator.generate(
-            stix2generator.utils.STIXTypeClass.SCO
+            stix2.utils.STIXTypeClass.SCO
         )
 
         return container

--- a/stix2generator/generation/stix_generator.py
+++ b/stix2generator/generation/stix_generator.py
@@ -61,8 +61,8 @@ def _random_id_of_types(by_type, *types, stix_version="2.1"):
     num_ids = sum(
         len(ids)
         for type_, ids in by_type.items()
-        if stix2generator.utils.is_stix_type(
-            type_, *types, stix_version=stix_version
+        if stix2.utils.is_stix_type(
+            type_, stix_version, *types
         )
     )
 
@@ -73,8 +73,8 @@ def _random_id_of_types(by_type, *types, stix_version="2.1"):
         id_iter = itertools.chain.from_iterable(
             ids
             for type_, ids in by_type.items()
-            if stix2generator.utils.is_stix_type(
-                type_, *types, stix_version=stix_version
+            if stix2.utils.is_stix_type(
+                type_, stix_version, *types
             )
         )
 
@@ -96,11 +96,11 @@ def _is_sro_connectable(obj_or_type, stix_version):
     :param stix_version: A STIX version as a string
     :return: True if the type is connectable via SRO; False if not
     """
-    return stix2generator.utils.is_stix_type(
+    return stix2.utils.is_stix_type(
         obj_or_type,
-        stix2generator.utils.STIXTypeClass.SDO,
-        stix2generator.utils.STIXTypeClass.SCO,
-        stix_version=stix_version
+        stix_version,
+        stix2.utils.STIXTypeClass.SDO,
+        stix2.utils.STIXTypeClass.SCO,
     )
 
 
@@ -116,9 +116,9 @@ def _random_sro_connectable_id(by_type, stix_version):
     """
     return _random_id_of_types(
         by_type,
-        stix2generator.utils.STIXTypeClass.SDO,
-        stix2generator.utils.STIXTypeClass.SCO,
-        stix_version=stix_version
+        stix_version,
+        stix2.utils.STIXTypeClass.SDO,
+        stix2.utils.STIXTypeClass.SCO,
     )
 
 
@@ -325,7 +325,7 @@ class STIXGenerator:
         :param by_type: Additional bookkeeping: a map from STIX type to a list
             of IDs of STIX objects in the current graph of that type
         :param required_types: Type constraints, as a sequence of STIX type
-            strings and/or stix2generator.utils.STIXTypeClass enum values.  A
+            strings and/or stix2.utils.STIXTypeClass enum values.  A
             type constraint must be given, otherwise no satisfying type will
             exist.
         :return: A STIX ID whose type satisfies the given type constraints
@@ -398,7 +398,7 @@ class STIXGenerator:
         """
 
         if any(
-                stix2generator.utils.is_sdo(type_, self.__stix_version)
+                stix2.utils.is_sdo(type_, self.__stix_version)
                 for type_ in by_type
         ):
             sighting = self.__object_generator.generate("sighting")
@@ -438,7 +438,7 @@ class STIXGenerator:
 
                 # Connect via sighting_of_ref
                 sighting_of_id = _random_id_of_types(
-                    by_type, stix2generator.utils.STIXTypeClass.SDO,
+                    by_type, stix2.utils.STIXTypeClass.SDO,
                     stix_version=self.__stix_version
                 )
                 sighting["sighting_of_ref"] = sighting_of_id
@@ -447,7 +447,7 @@ class STIXGenerator:
             # not connect to existing graph nodes.
             if sighting["sighting_of_ref"] not in by_id:
                 sighting["sighting_of_ref"] = self.__random_get_id(
-                    by_id, by_type, stix2generator.utils.STIXTypeClass.SDO
+                    by_id, by_type, stix2.utils.STIXTypeClass.SDO
                 )
 
             if observed_data_refs:
@@ -566,8 +566,8 @@ class STIXGenerator:
             # type.  So just use related-to with a random type.
 
             endpoint_type2 = self.__random_generatable_stix_type(
-                stix2generator.utils.STIXTypeClass.SDO,
-                stix2generator.utils.STIXTypeClass.SCO
+                stix2.utils.STIXTypeClass.SDO,
+                stix2.utils.STIXTypeClass.SCO
             )
             endpoint_object2 = self.__object_generator.generate(
                 endpoint_type2
@@ -607,7 +607,7 @@ class STIXGenerator:
         """
 
         if not seed_type:
-            seed_type = stix2generator.utils.STIXTypeClass.SDO
+            seed_type = stix2.utils.STIXTypeClass.SDO
 
         # Might seem kinda silly if seed_type is directly given as a string,
         # but this ensures that the given seed type is actually generatable

--- a/stix2generator/generation/stix_generator.py
+++ b/stix2generator/generation/stix_generator.py
@@ -69,8 +69,8 @@ def _random_id_of_types(by_type, *types, stix_version="2.1"):
     num_ids = sum(
         len(ids)
         for type_, ids in by_type.items()
-        if stix2generator.utils.is_stix_type(
-            type_, *types, stix_version=stix_version
+        if stix2.utils.is_stix_type(
+            type_, stix_version, *types
         )
     )
 
@@ -81,8 +81,8 @@ def _random_id_of_types(by_type, *types, stix_version="2.1"):
         id_iter = itertools.chain.from_iterable(
             ids
             for type_, ids in by_type.items()
-            if stix2generator.utils.is_stix_type(
-                type_, *types, stix_version=stix_version
+            if stix2.utils.is_stix_type(
+                type_, stix_version, *types
             )
         )
 
@@ -104,11 +104,11 @@ def _is_sro_connectable(obj_or_type, stix_version):
     :param stix_version: A STIX version as a string
     :return: True if the type is connectable via SRO; False if not
     """
-    return stix2generator.utils.is_stix_type(
+    return stix2.utils.is_stix_type(
         obj_or_type,
-        stix2generator.utils.STIXTypeClass.SDO,
-        stix2generator.utils.STIXTypeClass.SCO,
-        stix_version=stix_version
+        stix_version,
+        stix2.utils.STIXTypeClass.SDO,
+        stix2.utils.STIXTypeClass.SCO,
     )
 
 
@@ -124,9 +124,9 @@ def _random_sro_connectable_id(by_type, stix_version):
     """
     return _random_id_of_types(
         by_type,
-        stix2generator.utils.STIXTypeClass.SDO,
-        stix2generator.utils.STIXTypeClass.SCO,
-        stix_version=stix_version
+        stix_version,
+        stix2.utils.STIXTypeClass.SDO,
+        stix2.utils.STIXTypeClass.SCO,
     )
 
 
@@ -333,7 +333,7 @@ class STIXGenerator:
         :param by_type: Additional bookkeeping: a map from STIX type to a list
             of IDs of STIX objects in the current graph of that type
         :param required_types: Type constraints, as a sequence of STIX type
-            strings and/or stix2generator.utils.STIXTypeClass enum values.  A
+            strings and/or stix2.utils.STIXTypeClass enum values.  A
             type constraint must be given, otherwise no satisfying type will
             exist.
         :return: A STIX ID whose type satisfies the given type constraints
@@ -406,7 +406,7 @@ class STIXGenerator:
         """
 
         if any(
-                stix2generator.utils.is_sdo(type_, self.__stix_version)
+                stix2.utils.is_sdo(type_, self.__stix_version)
                 for type_ in by_type
         ):
             sighting = self.__object_generator.generate("sighting")
@@ -446,7 +446,7 @@ class STIXGenerator:
 
                 # Connect via sighting_of_ref
                 sighting_of_id = _random_id_of_types(
-                    by_type, stix2generator.utils.STIXTypeClass.SDO,
+                    by_type, stix2.utils.STIXTypeClass.SDO,
                     stix_version=self.__stix_version
                 )
                 sighting["sighting_of_ref"] = sighting_of_id
@@ -455,7 +455,7 @@ class STIXGenerator:
             # not connect to existing graph nodes.
             if sighting["sighting_of_ref"] not in by_id:
                 sighting["sighting_of_ref"] = self.__random_get_id(
-                    by_id, by_type, stix2generator.utils.STIXTypeClass.SDO
+                    by_id, by_type, stix2.utils.STIXTypeClass.SDO
                 )
 
             if observed_data_refs:
@@ -574,8 +574,8 @@ class STIXGenerator:
             # type.  So just use related-to with a random type.
 
             endpoint_type2 = self.__random_generatable_stix_type(
-                stix2generator.utils.STIXTypeClass.SDO,
-                stix2generator.utils.STIXTypeClass.SCO
+                stix2.utils.STIXTypeClass.SDO,
+                stix2.utils.STIXTypeClass.SCO
             )
             endpoint_object2 = self.__object_generator.generate(
                 endpoint_type2
@@ -615,7 +615,7 @@ class STIXGenerator:
         """
 
         if not seed_type:
-            seed_type = stix2generator.utils.STIXTypeClass.SDO
+            seed_type = stix2.utils.STIXTypeClass.SDO
 
         # Might seem kinda silly if seed_type is directly given as a string,
         # but this ensures that the given seed type is actually generatable

--- a/stix2generator/test/test_reference_graph_generator.py
+++ b/stix2generator/test/test_reference_graph_generator.py
@@ -1,7 +1,7 @@
 import copy
 import pytest
 import stix2.base
-import stix2.v21
+import stix2.utils
 import stix2generator
 import stix2generator.test.utils
 import stix2generator.utils
@@ -20,9 +20,9 @@ _TLP_MARKING_DEFINITION_IDS = {
 @pytest.mark.parametrize(
     "seed_type", [
         "identity",
-        stix2generator.utils.STIXTypeClass.SDO,
-        stix2generator.utils.STIXTypeClass.SCO,
-        stix2generator.utils.STIXTypeClass.SRO
+        stix2.utils.STIXTypeClass.SDO,
+        stix2.utils.STIXTypeClass.SCO,
+        stix2.utils.STIXTypeClass.SRO
     ]
 )
 def test_seeds(num_trials, seed_type):
@@ -40,8 +40,8 @@ def test_seeds(num_trials, seed_type):
 
         # Ensure the graph has at least one object of type seed_type.
         assert any(
-            stix2generator.utils.is_stix_type(
-                obj, seed_type, stix_version="2.1"
+            stix2.utils.is_stix_type(
+                obj, "2.1", seed_type
             )
             for obj in graph.values()
         )

--- a/stix2generator/test/test_reference_graph_generator.py
+++ b/stix2generator/test/test_reference_graph_generator.py
@@ -1,6 +1,7 @@
 import copy
 import pytest
 import stix2.base
+import stix2.utils
 import stix2generator
 import stix2generator.test.utils
 import stix2generator.utils
@@ -19,9 +20,9 @@ _TLP_MARKING_DEFINITION_IDS = {
 @pytest.mark.parametrize(
     "seed_type", [
         "identity",
-        stix2generator.utils.STIXTypeClass.SDO,
-        stix2generator.utils.STIXTypeClass.SCO,
-        stix2generator.utils.STIXTypeClass.SRO
+        stix2.utils.STIXTypeClass.SDO,
+        stix2.utils.STIXTypeClass.SCO,
+        stix2.utils.STIXTypeClass.SRO
     ]
 )
 def test_seeds(num_trials, seed_type):
@@ -39,8 +40,8 @@ def test_seeds(num_trials, seed_type):
 
         # Ensure the graph has at least one object of type seed_type.
         assert any(
-            stix2generator.utils.is_stix_type(
-                obj, seed_type, stix_version="2.1"
+            stix2.utils.is_stix_type(
+                obj, "2.1", seed_type
             )
             for obj in graph.values()
         )

--- a/stix2generator/test/test_stix2_auto_registration.py
+++ b/stix2generator/test/test_stix2_auto_registration.py
@@ -2,7 +2,7 @@ import pytest
 import stix2
 
 try:
-    import stix2.parsing as mappings
+    import stix2.registry as mappings
 except ImportError:
     import stix2.core as mappings
 

--- a/stix2generator/test/test_stix_generation.py
+++ b/stix2generator/test/test_stix_generation.py
@@ -1,6 +1,7 @@
 import itertools
 import pytest
 import stix2.base
+import stix2.utils
 
 import stix2generator
 import stix2generator.exceptions
@@ -13,9 +14,9 @@ import stix2generator.generation.stix_generator
 @pytest.mark.parametrize(
     "seed_type", [
         "identity",
-        stix2generator.utils.STIXTypeClass.SDO,
-        stix2generator.utils.STIXTypeClass.SCO,
-        stix2generator.utils.STIXTypeClass.SRO
+        stix2.utils.STIXTypeClass.SDO,
+        stix2.utils.STIXTypeClass.SCO,
+        stix2.utils.STIXTypeClass.SRO
     ]
 )
 def test_seeds(num_trials, seed_type, stix21_generator):
@@ -24,8 +25,8 @@ def test_seeds(num_trials, seed_type, stix21_generator):
 
         # Ensure the graph has at least one object of type seed_type.
         assert any(
-            stix2generator.utils.is_stix_type(
-                obj, seed_type, stix_version="2.1"
+            stix2.utils.is_stix_type(
+                obj, "2.1", seed_type
             )
             for obj in graph.values()
         )
@@ -41,7 +42,7 @@ def _count_relationships(graph):
     Counts the number of relationships (plain and sighting) in the graph.
     """
     count = sum(
-        1 if stix2generator.utils.is_sro(obj) else 0
+        1 if stix2.utils.is_sro(obj, "2.1") else 0
         for obj in graph.values()
     )
 
@@ -97,7 +98,7 @@ def test_complete_ref_properties_false(num_trials):
         # object.
         for id_, obj in graph.items():
 
-            if not stix2generator.utils.is_sro(obj):
+            if not stix2.utils.is_sro(obj, "2.1"):
                 first_ref = next(
                     stix2generator.utils.find_references(obj), None
                 )
@@ -285,7 +286,7 @@ def _sro_cycle_undirected_dfs(
             # Need to add the SROs to the stack too, because we don't want to
             # reuse them in a cycle.  Cycles require distinct objects *and*
             # distinct SROs.
-            if stix2generator.utils.is_sro(obj) \
+            if stix2.utils.is_sro(obj, "2.1") \
                     and id_ not in search_stack \
                     and _sro_relates(obj, curr_id):
 
@@ -323,11 +324,11 @@ def _has_sro_cycle_undirected(graph):
     """
     # Need to find a start node, i.e. a SRO-connectable object in the graph.
     sro_connectable_ids = (
-        id_ for id_, obj in graph.items() if stix2generator.utils.is_stix_type(
+        id_ for id_, obj in graph.items() if stix2.utils.is_stix_type(
             obj,
-            stix2generator.utils.STIXTypeClass.SDO,
-            stix2generator.utils.STIXTypeClass.SCO,
-            stix_version="2.1"
+            "2.1",
+            stix2.utils.STIXTypeClass.SDO,
+            stix2.utils.STIXTypeClass.SCO,
         )
     )
 

--- a/stix2generator/test/test_utils.py
+++ b/stix2generator/test/test_utils.py
@@ -1,6 +1,7 @@
 # Unit tests for the (top-level) utils module.
 import pytest
 
+import stix2.utils
 import stix2generator.utils
 
 
@@ -44,168 +45,14 @@ def test_find_references_assignable(obj):
 
 
 @pytest.mark.parametrize(
-    "obj_or_type, stix_version, expected", [
-        ("identity", "2.1", True),
-        ("identity", "2.0", True),
-        ("ipv4-addr", "2.1", False),
-        ("ipv4-addr", "2.0", False),
-        ("bundle", "2.1", False),
-        ("bundle", "2.0", False),
-        ("marking-definition", "2.1", False),
-        ("marking-definition", "2.0", False),
-        ("foobar", "2.1", False),
-        ("foobar", "2.0", False),
-        ("relationship", "2.1", False),
-        ("relationship", "2.0", False),
-        ({"type": "malware-analysis", "foo": 1}, "2.1", True),
-        ({"type": "malware-analysis", "foo": 1}, "2.0", False)
-    ]
-)
-def test_is_sdo(obj_or_type, stix_version, expected):
-    assert stix2generator.utils.is_sdo(obj_or_type, stix_version) is expected
-    assert stix2generator.utils.is_stix_type(
-        obj_or_type, stix2generator.utils.STIXTypeClass.SDO,
-        stix_version=stix_version
-    ) is expected
-
-
-@pytest.mark.parametrize(
-    "obj_or_type, stix_version, expected", [
-        ("identity", "2.1", False),
-        ("identity", "2.0", False),
-        ("ipv4-addr", "2.1", True),
-        ("ipv4-addr", "2.0", True),
-        ("bundle", "2.1", False),
-        ("bundle", "2.0", False),
-        ("marking-definition", "2.1", False),
-        ("marking-definition", "2.0", False),
-        ("foobar", "2.1", False),
-        ("foobar", "2.0", False),
-        ("relationship", "2.1", False),
-        ("relationship", "2.0", False),
-        ({"type": "mutex", "foo": 1}, "2.1", True),
-        ({"type": "mutex", "foo": 1}, "2.0", True)
-    ]
-)
-def test_is_sco(obj_or_type, stix_version, expected):
-    assert stix2generator.utils.is_sco(obj_or_type, stix_version) is expected
-    assert stix2generator.utils.is_stix_type(
-        obj_or_type, stix2generator.utils.STIXTypeClass.SCO,
-        stix_version=stix_version
-    ) is expected
-
-
-@pytest.mark.parametrize(
-    "obj_or_type, stix_version, expected", [
-        ("identity", "2.1", False),
-        ("identity", "2.0", False),
-        ("ipv4-addr", "2.1", False),
-        ("ipv4-addr", "2.0", False),
-        ("bundle", "2.1", False),
-        ("bundle", "2.0", False),
-        ("marking-definition", "2.1", False),
-        ("marking-definition", "2.0", False),
-        ("foobar", "2.1", False),
-        ("foobar", "2.0", False),
-        ("relationship", "2.1", True),
-        ("relationship", "2.0", True),
-        ("sighting", "2.1", True),
-        ("sighting", "2.0", True),
-        ({"type": "mutex", "foo": 1}, "2.1", False),
-        ({"type": "mutex", "foo": 1}, "2.0", False)
-    ]
-)
-def test_is_sro(obj_or_type, stix_version, expected):
-    assert stix2generator.utils.is_sro(obj_or_type, stix_version) is expected
-    assert stix2generator.utils.is_stix_type(
-        obj_or_type, stix2generator.utils.STIXTypeClass.SRO,
-        stix_version=stix_version
-    ) is expected
-
-
-@pytest.mark.parametrize(
-    "obj_or_type, stix_version, expected", [
-        ("identity", "2.1", True),
-        ("identity", "2.0", True),
-        ("ipv4-addr", "2.1", True),
-        ("ipv4-addr", "2.0", True),
-        ("bundle", "2.1", True),
-        ("bundle", "2.0", True),
-        ("marking-definition", "2.1", True),
-        ("marking-definition", "2.0", True),
-        ("foobar", "2.1", False),
-        ("foobar", "2.0", False),
-        ("relationship", "2.1", True),
-        ("relationship", "2.0", True),
-        ({"type": "mutex", "foo": 1}, "2.1", True),
-        ({"type": "mutex", "foo": 1}, "2.0", True)
-    ]
-)
-def test_is_object(obj_or_type, stix_version, expected):
-    assert stix2generator.utils.is_object(obj_or_type, stix_version) is expected
-
-
-@pytest.mark.parametrize(
-    "obj_or_type, constraints, expected", [
-        (
-            "identity", (
-                stix2generator.utils.STIXTypeClass.SDO,
-                stix2generator.utils.STIXTypeClass.SCO
-            ),
-            True
-        ),
-        (
-            "identity", (
-                "identity",
-                stix2generator.utils.STIXTypeClass.SCO
-            ),
-            True
-        ),
-        (
-            "identity", (
-                stix2generator.utils.STIXTypeClass.SDO,
-                "malware"
-            ),
-            True
-        ),
-        (
-            "identity", (
-                "location",
-                "identity"
-            ),
-            True
-        ),
-        (
-            "identity", (
-                "location",
-                "malware"
-            ),
-            False
-        ),
-        (
-            "foobar", (
-                "location",
-                "malware"
-            ),
-            False
-        ),
-    ]
-)
-def test_is_stix_type(obj_or_type, constraints, expected):
-    assert stix2generator.utils.is_stix_type(
-        obj_or_type, *constraints, stix_version="2.1"
-    ) is expected
-
-
-@pytest.mark.parametrize(
     "constraints", [
         (("identity",)),
         (("identity", "location")),
-        ((stix2generator.utils.STIXTypeClass.SDO, "url")),
-        (("campaign", stix2generator.utils.STIXTypeClass.SCO)),
+        ((stix2.utils.STIXTypeClass.SDO, "url")),
+        (("campaign", stix2.utils.STIXTypeClass.SCO)),
         ((
-                stix2generator.utils.STIXTypeClass.SDO,
-                stix2generator.utils.STIXTypeClass.SCO
+                stix2.utils.STIXTypeClass.SDO,
+                stix2.utils.STIXTypeClass.SCO
         )),
     ]
 )
@@ -217,8 +64,8 @@ def test_random_generatable_stix_type(
             object_generator21, *constraints, stix_version="2.1"
         )
 
-        assert stix2generator.utils.is_stix_type(
-            type_, *constraints, stix_version="2.1"
+        assert stix2.utils.is_stix_type(
+            type_, "2.1", *constraints
         )
 
         # try to generate an object to see if there is an error

--- a/stix2generator/utils.py
+++ b/stix2generator/utils.py
@@ -4,11 +4,6 @@ import lark
 import stix2.registry
 import stix2.utils
 
-try:
-    import stix2.parsing as mappings
-except ImportError:
-    import stix2.core as mappings
-
 
 def is_tree(node, rule_name=None):
     """

--- a/stix2generator/utils.py
+++ b/stix2generator/utils.py
@@ -1,7 +1,8 @@
 import collections.abc
-import enum
 import random
 import lark
+import stix2.registry
+import stix2.utils
 
 try:
     import stix2.parsing as mappings
@@ -173,169 +174,13 @@ def find_references_assignable(obj):
                 yield from recurse_references_assignable(value)
 
 
-def _stix_type_of(obj_or_type):
-    """
-    Get a STIX type from the given value: if a string is passed, it is assumed
-    to be a STIX type and is returned; otherwise it is assumed to be a mapping
-    with a "type" property, and the value of that property is returned.
-
-    :param obj_or_type: A mapping with a "type" property, or a STIX type
-        as a string
-    :return: A STIX type
-    """
-    if isinstance(obj_or_type, str):
-        type_ = obj_or_type
-    else:
-        type_ = obj_or_type["type"]
-
-    return type_
-
-
-def _get_stix2_class_maps(stix_version):
-    """
-    Get the stix2 class mappings for the given STIX version.
-    :param stix_version:  A STIX version as a string
-    :return: The class mappings.  This will be a dict mapping from some general
-        category name, e.g. "object" to another mapping from STIX type
-        to a stix2 class.
-    """
-    stix_vid = "v" + stix_version.replace(".", "")
-    cls_maps = mappings.STIX2_OBJ_MAPS[stix_vid]
-
-    return cls_maps
-
-
-def is_sdo(obj_or_type, stix_version="2.1"):
-    """
-    Determine whether the given object or type is an SDO.
-
-    :param obj_or_type: A mapping with a "type" property, or a STIX type
-        as a string
-    :param stix_version:  A STIX version as a string
-    :return: True if the object is an SDO or the type is an SDO type; False
-        if not
-    """
-
-    # Eventually this needs to be moved into the stix2 library (and maybe
-    # improved?); see cti-python-stix2 github issue #450.
-
-    cls_maps = _get_stix2_class_maps(stix_version)
-    type_ = _stix_type_of(obj_or_type)
-    result = type_ in cls_maps["objects"] and type_ not in {
-        "relationship", "sighting", "marking-definition", "bundle",
-        "language-content"
-    }
-
-    return result
-
-
-def is_sco(obj_or_type, stix_version="2.1"):
-    """
-    Determine whether the given object or type is an SCO.
-
-    :param obj_or_type: A mapping with a "type" property, or a STIX type
-        as a string
-    :param stix_version:  A STIX version as a string
-    :return: True if the object is an SCO or the type is an SCO type; False
-        if not
-    """
-    cls_maps = _get_stix2_class_maps(stix_version)
-    type_ = _stix_type_of(obj_or_type)
-    result = type_ in cls_maps["observables"]
-
-    return result
-
-
-def is_sro(obj_or_type, stix_version="2.1"):
-    """
-    Determine whether the given object or type is an SRO.
-
-    :param obj_or_type: A mapping with a "type" property, or a STIX type
-        as a string
-    :param stix_version:  A STIX version as a string
-    :return: True if the object is an SRO or the type is an SRO type; False
-        if not
-    """
-
-    # No STIX version dependence here yet...
-    type_ = _stix_type_of(obj_or_type)
-    result = type_ in ("sighting", "relationship")
-
-    return result
-
-
-def is_object(obj_or_type, stix_version="2.1"):
-    """
-    Determine whether a type is the type of any STIX object.  This includes all
-    SDOs, SCOs, meta-objects, and bundle.  If obj_or_type is an object, the
-    object's "type" property is checked.
-
-    :param obj_or_type: A mapping with a "type" property, or a STIX type
-        as a string
-    :param stix_version:  A STIX version as a string
-    :return: True if the (object) type is recognized as a STIX type with
-        respect to the given STIX version; False if not
-    """
-    cls_maps = _get_stix2_class_maps(stix_version)
-    type_ = _stix_type_of(obj_or_type)
-    result = type_ in cls_maps["observables"] or type_ in cls_maps["objects"]
-
-    return result
-
-
-class STIXTypeClass(enum.Enum):
-    """
-    Represents different classes of STIX type.
-    """
-    SDO = 0
-    SCO = 1
-    SRO = 2
-
-
-def is_stix_type(obj_or_type, *types, stix_version="2.1"):
-    """
-    Determine whether the given object or type satisfies the given constraints.
-    'types' must contain STIX types as strings, and/or the STIXTypeClass enum
-    values.  STIX types imply an exact match constraint; STIXTypeClass enum
-    values imply a more general constraint, that the object or type be in that
-    class of STIX type.  These constraints are implicitly OR'd together.
-
-    :param obj_or_type: A mapping with a "type" property, or a STIX type
-        as a string
-    :param types: A sequence of STIX type strings or STIXTypeClass enum values
-    :param stix_version:  A STIX version as a string
-    :return: True if the object or type satisfies the constraints; False if not
-    """
-
-    for type_ in types:
-        if type_ is STIXTypeClass.SDO:
-            result = is_sdo(obj_or_type, stix_version)
-        elif type_ is STIXTypeClass.SCO:
-            result = is_sco(obj_or_type, stix_version)
-        elif type_ is STIXTypeClass.SRO:
-            result = is_sro(obj_or_type, stix_version)
-        else:
-            # Assume a string STIX type is given instead of a class enum,
-            # and just check for exact match.
-            obj_type = _stix_type_of(obj_or_type)
-            result = is_object(obj_type, stix_version) and obj_type == type_
-
-        if result:
-            break
-
-    else:
-        result = False
-
-    return result
-
-
 def random_generatable_stix_type(
     object_generator, *required_types, stix_version="2.1"
 ):
     """
     Choose a STIX type at random which satisfies the given type constraints,
     and which the given object generator is able to generate.  See
-    is_stix_type() for more discussion on the type constraints.
+    stix2.utils.is_stix_type() for more discussion on the type constraints.
 
     :param object_generator: An object generator
     :param required_types: Type constraints, as a sequence of STIX type strings
@@ -348,7 +193,9 @@ def random_generatable_stix_type(
 
     candidate_types = [
         type_ for type_ in object_generator.spec_names
-        if is_stix_type(type_, *required_types, stix_version=stix_version)
+        if stix2.utils.is_stix_type(
+            type_, stix_version, *required_types
+        )
     ]
 
     if candidate_types:
@@ -370,8 +217,7 @@ def make_bundle(stix_objs, stix_version):
     :return: The Bundle object
     """
 
-    cls_maps = _get_stix2_class_maps(stix_version)
-    bundle_class = cls_maps["objects"]["bundle"]
+    bundle_class = stix2.registry.class_for_type("bundle", stix_version)
     bundle = bundle_class(stix_objs, allow_custom=True)
 
     return bundle


### PR DESCRIPTION
This PR makes changes necessary to maintain compatibility with the stix2 library master branch.

Tox tests will fail until a new release is made of the stix2 library.