### PR TITLE
Add "parse" config setting

### DIFF
--- a/stix2generator/generation/semantics.py
+++ b/stix2generator/generation/semantics.py
@@ -333,9 +333,8 @@ class STIXSemantics(SemanticsProvider):
             stix2generator.generation.reference_graph_generator\
             .ReferenceGraphGenerator(generator, config)
 
-        sco_type = stix2generator.utils.random_generatable_stix_type(
-            generator, stix2generator.utils.STIXTypeClass.SCO
+        _, container = observable_container_generator.generate(
+            stix2generator.utils.STIXTypeClass.SCO
         )
-        _, container = observable_container_generator.generate(sco_type)
 
         return container

--- a/stix2generator/generation/semantics.py
+++ b/stix2generator/generation/semantics.py
@@ -321,6 +321,11 @@ class STIXSemantics(SemanticsProvider):
         config_kwargs.pop("type")
         config_kwargs.pop(SEMANTIC_PROPERTY_NAME)
 
+        # Force this setting.  ObjectGenerator really needs to produce the
+        # plain JSON values, not parsed stix2 objects, so this setting becomes
+        # a necessity in this context.
+        config_kwargs["parse"] = False
+
         config = stix2generator.generation.reference_graph_generator.Config(
             **config_kwargs
         )

--- a/stix2generator/test/test_reference_graph_generator.py
+++ b/stix2generator/test/test_reference_graph_generator.py
@@ -606,6 +606,21 @@ def test_delete_inverse_properties(src_obj, ref_prop, dest_obj):
     )
 
 
+def test_no_dangling_references(num_trials):
+    obj_gen_config = stix2generator.generation.object_generator.Config(
+        minimize_ref_properties=False
+    )
+    obj_gen = stix2generator.create_object_generator(obj_gen_config)
+    ref_graph_gen = stix2generator.generation.reference_graph_generator \
+        .ReferenceGraphGenerator(
+        obj_gen
+    )
+
+    for _ in range(num_trials):
+        _, graph = ref_graph_gen.generate()
+        assert not stix2generator.test.utils.has_dangling_references(graph)
+
+
 def _has_cycle(graph):
 
     # This is kinda silly, doing repeated reachability tests (a single DFS

--- a/stix2generator/test/test_reference_graph_generator.py
+++ b/stix2generator/test/test_reference_graph_generator.py
@@ -613,8 +613,8 @@ def test_no_dangling_references(num_trials):
     obj_gen = stix2generator.create_object_generator(obj_gen_config)
     ref_graph_gen = stix2generator.generation.reference_graph_generator \
         .ReferenceGraphGenerator(
-        obj_gen
-    )
+            obj_gen
+        )
 
     for _ in range(num_trials):
         _, graph = ref_graph_gen.generate()
@@ -933,8 +933,8 @@ def test_not_parsing(num_trials):
 
     ref_graph_config = stix2generator.generation.reference_graph_generator \
         .Config(
-        parse=False
-    )
+            parse=False
+        )
     ref_graph_gen = stix2generator.generation.reference_graph_generator \
         .ReferenceGraphGenerator(obj_gen, ref_graph_config, stix_version="2.1")
 

--- a/stix2generator/test/test_reference_graph_generator.py
+++ b/stix2generator/test/test_reference_graph_generator.py
@@ -863,7 +863,7 @@ def test_graph_delete_inverse_properties(num_trials):
 # anything goes.
 
 
-def test_preexisting_objects():
+def test_preexisting_objects(num_trials):
     obj_gen_config = stix2generator.generation.object_generator.Config(
         minimize_ref_properties=False
     )
@@ -872,21 +872,22 @@ def test_preexisting_objects():
     ref_graph_gen = stix2generator.generation.reference_graph_generator \
         .ReferenceGraphGenerator(obj_gen, stix_version="2.1")
 
-    _, graph1 = ref_graph_gen.generate()
+    for _ in range(num_trials):
+        _, graph1 = ref_graph_gen.generate()
 
-    _, graph2 = ref_graph_gen.generate(preexisting_objects=graph1)
+        _, graph2 = ref_graph_gen.generate(preexisting_objects=graph1)
 
-    # just ensure graph2 absorbed graph1.  Anything else we can test?
-    assert all(id_ in graph2 for id_ in graph1)
+        # just ensure graph2 absorbed graph1.  Anything else we can test?
+        assert all(id_ in graph2 for id_ in graph1)
 
-    # ensure all objects got parsed ok
-    assert all(
-        isinstance(obj, stix2.base._STIXBase)
-        for obj in graph2.values()
-    )
+        # ensure all objects got parsed ok
+        assert all(
+            isinstance(obj, stix2.base._STIXBase)
+            for obj in graph2.values()
+        )
 
 
-def test_stix2_parsing():
+def test_stix2_parsing(num_trials):
     obj_gen_config = stix2generator.generation.object_generator.Config(
         minimize_ref_properties=False
     )
@@ -905,25 +906,26 @@ def test_stix2_parsing():
         # validation errors.
     }
 
-    graph1 = {
-        identity["id"]: identity
-    }
+    for _ in range(num_trials):
+        graph1 = {
+            identity["id"]: identity
+        }
 
-    _, graph2 = ref_graph_gen.generate(preexisting_objects=graph1)
+        _, graph2 = ref_graph_gen.generate(preexisting_objects=graph1)
 
-    # ensure graph2 absorbed graph1
-    assert graph1.keys() <= graph2.keys()
+        # ensure graph2 absorbed graph1
+        assert graph1.keys() <= graph2.keys()
 
-    # ensure our preexisting identity is still a dict, but other objects were
-    # parsed.
-    for id_, obj in graph2.items():
-        if id_ == identity["id"]:
-            assert isinstance(obj, dict)
-        else:
-            assert isinstance(obj, stix2.base._STIXBase)
+        # ensure our preexisting identity is still a dict, but other objects
+        # were parsed.
+        for id_, obj in graph2.items():
+            if id_ == identity["id"]:
+                assert isinstance(obj, dict)
+            else:
+                assert isinstance(obj, stix2.base._STIXBase)
 
 
-def test_not_parsing():
+def test_not_parsing(num_trials):
     obj_gen_config = stix2generator.generation.object_generator.Config(
         minimize_ref_properties=False
     )
@@ -940,19 +942,20 @@ def test_not_parsing():
         name="Alice"
     )
 
-    graph1 = {
-        identity.id: identity
-    }
+    for _ in range(num_trials):
+        graph1 = {
+            identity.id: identity
+        }
 
-    _, graph2 = ref_graph_gen.generate(preexisting_objects=graph1)
+        _, graph2 = ref_graph_gen.generate(preexisting_objects=graph1)
 
-    # ensure graph2 absorbed graph1
-    assert graph1.keys() <= graph2.keys()
+        # ensure graph2 absorbed graph1
+        assert graph1.keys() <= graph2.keys()
 
-    # Ensure the only parsed object is our original identity.
-    for id_, obj in graph2.items():
-        if id_ == identity.id:
-            assert isinstance(obj, stix2.v21.Identity)
+        # Ensure the only parsed object is our original identity.
+        for id_, obj in graph2.items():
+            if id_ == identity.id:
+                assert isinstance(obj, stix2.v21.Identity)
 
-        else:
-            assert isinstance(obj, dict)
+            else:
+                assert isinstance(obj, dict)

--- a/stix2generator/test/test_stix21_registry.py
+++ b/stix2generator/test/test_stix21_registry.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import stix2
 import stix2.exceptions
@@ -70,6 +71,9 @@ def test_generation_random_props(generator_random_props, spec_name, num_trials):
     for _ in range(num_trials):
         obj_dict = generator_random_props.generate(spec_name)
 
+        # Ensure json-serializability
+        json.dumps(obj_dict, ensure_ascii=False)
+
         # Distinguish between a STIX object spec and a "helper" spec used
         # by STIX object specs.  Only makes sense to stix2.parse() the former.
         if spec_name[0].isupper():
@@ -87,6 +91,9 @@ def test_generation_min_props(generator_min_props, spec_name):
 
     obj_dict = generator_min_props.generate(spec_name)
 
+    # Ensure json-serializability
+    json.dumps(obj_dict, ensure_ascii=False)
+
     # Distinguish between a STIX object spec and a "helper" spec used
     # by STIX object specs.  Only makes sense to stix2.parse() the former.
     if spec_name[0].isupper():
@@ -103,6 +110,9 @@ def test_generation_min_props(generator_min_props, spec_name):
 def test_generation_all_props(generator_all_props, spec_name):
 
     obj_dict = generator_all_props.generate(spec_name)
+
+    # Ensure json-serializability
+    json.dumps(obj_dict, ensure_ascii=False)
 
     # Distinguish between a STIX object spec and a "helper" spec used
     # by STIX object specs.  Only makes sense to stix2.parse() the former.
@@ -125,16 +135,19 @@ def test_generation_random_props_relationship(
 ):
     for _ in range(num_trials):
         rel_dict = generator_random_props.generate("relationship")
+        json.dumps(rel_dict, ensure_ascii=False)
         stix2.parse(rel_dict, version="2.1")
 
 
 def test_generation_min_props_relationship(generator_min_props):
     rel_dict = generator_min_props.generate("relationship")
+    json.dumps(rel_dict, ensure_ascii=False)
     stix2.parse(rel_dict, version="2.1")
 
 
 def test_generation_all_props_relationship(generator_all_props):
     rel_dict = generator_all_props.generate("relationship")
+    json.dumps(rel_dict, ensure_ascii=False)
     stix2.parse(rel_dict, version="2.1")
 
 
@@ -145,14 +158,17 @@ def test_generation_random_props_sighting(
 ):
     for _ in range(num_trials):
         rel_dict = generator_random_props.generate("sighting")
+        json.dumps(rel_dict, ensure_ascii=False)
         stix2.parse(rel_dict, version="2.1")
 
 
 def test_generation_min_props_sighting(generator_min_props):
     rel_dict = generator_min_props.generate("sighting")
+    json.dumps(rel_dict, ensure_ascii=False)
     stix2.parse(rel_dict, version="2.1")
 
 
 def test_generation_all_props_sighting(generator_all_props):
     rel_dict = generator_all_props.generate("sighting")
+    json.dumps(rel_dict, ensure_ascii=False)
     stix2.parse(rel_dict, version="2.1")

--- a/stix2generator/test/test_stix_generation.py
+++ b/stix2generator/test/test_stix_generation.py
@@ -477,8 +477,8 @@ def test_not_stix2_parsing(num_trials):
 
     ref_graph_config = stix2generator.generation.reference_graph_generator \
         .Config(
-        parse=False
-    )
+            parse=False
+        )
 
     stix_gen = stix2generator.create_stix_generator(
         stix_generator_config=stix_gen_config,
@@ -521,8 +521,8 @@ def test_mixed_parse1(num_trials):
 
     ref_graph_config = stix2generator.generation.reference_graph_generator \
         .Config(
-        parse=True
-    )
+            parse=True
+        )
 
     stix_gen = stix2generator.create_stix_generator(
         stix_generator_config=stix_gen_config,
@@ -548,8 +548,8 @@ def test_mixed_parse2(num_trials):
 
     ref_graph_config = stix2generator.generation.reference_graph_generator \
         .Config(
-        parse=False
-    )
+            parse=False
+        )
 
     stix_gen = stix2generator.create_stix_generator(
         stix_generator_config=stix_gen_config,

--- a/stix2generator/test/test_stix_generation.py
+++ b/stix2generator/test/test_stix_generation.py
@@ -424,22 +424,23 @@ def test_observed_data_observable_container(num_trials):
                 )
 
 
-def test_preexisting_objects(stix21_generator):
-    graph1 = stix21_generator.generate()
+def test_preexisting_objects(stix21_generator, num_trials):
+    for _ in range(num_trials):
+        graph1 = stix21_generator.generate()
 
-    graph2 = stix21_generator.generate(preexisting_objects=graph1)
+        graph2 = stix21_generator.generate(preexisting_objects=graph1)
 
-    # ensure graph2 absorbed graph1
-    assert graph1.keys() <= graph2.keys()
+        # ensure graph2 absorbed graph1
+        assert graph1.keys() <= graph2.keys()
 
-    # ensure all objects got parsed ok
-    assert all(
-        isinstance(obj, stix2.base._STIXBase)
-        for obj in graph2.values()
-    )
+        # ensure all objects got parsed ok
+        assert all(
+            isinstance(obj, stix2.base._STIXBase)
+            for obj in graph2.values()
+        )
 
 
-def test_stix2_parsing(stix21_generator):
+def test_stix2_parsing(stix21_generator, num_trials):
     identity = {
         "id": "identity--74fa9f1b-897e-40dc-8f1c-d2f531c956bb",
         "type": "identity",
@@ -450,22 +451,23 @@ def test_stix2_parsing(stix21_generator):
         # validation errors.
     }
 
-    graph1 = {
-        identity["id"]: identity
-    }
+    for _ in range(num_trials):
+        graph1 = {
+            identity["id"]: identity
+        }
 
-    graph2 = stix21_generator.generate(preexisting_objects=graph1)
+        graph2 = stix21_generator.generate(preexisting_objects=graph1)
 
-    # ensure graph2 absorbed graph1
-    assert graph1.keys() <= graph2.keys()
+        # ensure graph2 absorbed graph1
+        assert graph1.keys() <= graph2.keys()
 
-    # ensure our preexisting identity is still a dict, but other objects were
-    # parsed.
-    for id_, obj in graph2.items():
-        if id_ == identity["id"]:
-            assert isinstance(obj, dict)
-        else:
-            assert isinstance(obj, stix2.base._STIXBase)
+        # ensure our preexisting identity is still a dict, but other objects
+        # were parsed.
+        for id_, obj in graph2.items():
+            if id_ == identity["id"]:
+                assert isinstance(obj, dict)
+            else:
+                assert isinstance(obj, stix2.base._STIXBase)
 
 
 def test_not_stix2_parsing(num_trials):


### PR DESCRIPTION
Fixes #7 .

Add "parse" config setting for STIXGenerator and ReferenceGraphGenerator to allow users to inhibit parsing generated dicts to stix2 objects.  Switching parsing off will be necessary whenever ObjectGenerator makes use of either of the aforementioned generators.  This bug had to do with ReferenceGraphGenerator specifically, but for consistency's sake, I thought STIXGenerator should have the same capability.