### PR TITLE
Change version-related property specs of malware-analysis SDO spec to generate strings

### DIFF
--- a/stix2generator/stix21_registry.json
+++ b/stix2generator/stix21_registry.json
@@ -998,9 +998,8 @@
                 "semantics": "word"
             },
             "configuration_version": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 20
+                "type": "string",
+                "semantics": "word"
             },
             "modules": {
                 "type": "array",
@@ -1009,14 +1008,12 @@
                 }
             },
             "analysis_engine_version": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 20
+                "type": "string",
+                "semantics": "word"
             },
             "analysis_definition_version": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 20
+                "type": "string",
+                "semantics": "word"
             },
             "submitted": {
                 "type": "string",


### PR DESCRIPTION
Fixes #10 .

Change the specs for version-related properties of malware-analysis SDO so that they generate strings instead of integers.  The new specs use a random word.
