### PR TITLE
Fix a typo in the generator registry for the account-type-ov spec

### DIFF
--- a/stix2generator/stix21_registry.json
+++ b/stix2generator/stix21_registry.json
@@ -2593,7 +2593,7 @@
             "openid",
             "radius",
             "skype",
-            "tacas",
+            "tacacs",
             "twitter",
             "unix",
             "windows-local",


### PR DESCRIPTION
"tacas" -> "tacacs"

I found this while running the unit tests against the custom_revamp branch of the stix2 library, to check compatibility.  Open vocab customization enforcement works! :)