### PR TITLE
Fix fractional second precision in object generator timestamp strings

### DIFF
--- a/stix2generator/generation/semantics.py
+++ b/stix2generator/generation/semantics.py
@@ -219,9 +219,9 @@ class STIXSemantics(SemanticsProvider):
                 # choose a random timestamp within a year of the constraint
                 # timestamp...?
                 random_duration = datetime.timedelta(
-                    seconds=random.randint(
+                    microseconds=random.randrange(
                         0 if equal_allowed else 1,
-                        60 * 60 * 24 * 365 - 1
+                        10**6 * 60 * 60 * 24 * 365
                     )
                 )
 
@@ -252,7 +252,13 @@ class STIXSemantics(SemanticsProvider):
 
             timestamp_dt = now_dt + random_duration
 
-        timestamp_str = timestamp_dt.strftime(self._TIMESTAMP_FORMAT)
+        # Format fractional seconds to at least millisecond precision
+        frac_seconds_str = str(timestamp_dt.microsecond)
+        frac_seconds_str = frac_seconds_str.rstrip("0").ljust(3, "0")
+        timestamp_str = "{}.{}Z".format(
+            timestamp_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+            frac_seconds_str
+        )
 
         return timestamp_str
 

--- a/stix2generator/generation/semantics.py
+++ b/stix2generator/generation/semantics.py
@@ -253,7 +253,7 @@ class STIXSemantics(SemanticsProvider):
             timestamp_dt = now_dt + random_duration
 
         # Format fractional seconds to at least millisecond precision
-        frac_seconds_str = str(timestamp_dt.microsecond)
+        frac_seconds_str = "{:06d}".format(timestamp_dt.microsecond)
         frac_seconds_str = frac_seconds_str.rstrip("0").ljust(3, "0")
         timestamp_str = "{}.{}Z".format(
             timestamp_dt.strftime("%Y-%m-%dT%H:%M:%S"),

--- a/stix2generator/generation/semantics.py
+++ b/stix2generator/generation/semantics.py
@@ -241,9 +241,9 @@ class STIXSemantics(SemanticsProvider):
 
             # choose random within a year...?
             random_duration = datetime.timedelta(
-                seconds=random.randint(
+                microseconds=random.randrange(
                     0,
-                    60 * 60 * 24 * 365 - 1
+                    10**6 * 60 * 60 * 24 * 365
                 )
             )
 

--- a/stix2generator/test/test_object_generator_semantics.py
+++ b/stix2generator/test/test_object_generator_semantics.py
@@ -10,7 +10,7 @@ import stix2generator.generation.object_generator
 import stix2generator.generation.semantics
 
 
-_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 class DummySemantics(stix2generator.generation.semantics.SemanticsProvider):
@@ -126,7 +126,7 @@ def test_stix_semantics_timestamp_constraint(
     Test value constraint satisfaction in the stix-timestamp semantics
     implementation.
     """
-    constraint_ts_str = "2017-10-28T21:12:08Z"
+    constraint_ts_str = "2017-10-28T21:12:08.0Z"
     constraint_ts_dt = datetime.datetime.strptime(
         constraint_ts_str, _TIMESTAMP_FORMAT
     )


### PR DESCRIPTION
The timestamp semantic implementation didn't include fractional seconds.  This change causes timestamps to be generated with at least millisecond, and up to microsecond precision.  Timestamp value co-constraint application is changed to work at full precision.  For example, "ts1 > ts2" could result in timestamps one microsecond apart.