### PR TITLE
Fixes to get binder working better with this repo.

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+jupyter nbextension install stix2viz --py --user
+jupyter nbextension enable stix2viz --py --user
+

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,1 @@
+-e .[jupyter]

--- a/stix_notebook.py
+++ b/stix_notebook.py
@@ -60,7 +60,7 @@ def stix(line, cell):
     viz_config_json = json.dumps(viz_config)
 
     output = ''
-    output += ',\n'.join(map(str, stix_objs))
+    output += ',\n'.join(obj.serialize(pretty=True) for obj in stix_objs)
     if output[0] == '{':
         if len(stix_objs) > 1:
             output = '[' + output + ']'


### PR DESCRIPTION
- Adds a `binder/` directory which includes a `requirements.txt` file which binder will use in preference to setup.py, to install the library.  This installs specially with the `jupyter` "extra", which ensures the stix2-viz library is installed.
- Adds `binder/postBuild`, which is automatically run after the library installation, and installs and enables stix2-viz into jupyter as a jupyter notebook extension
- Fixes pretty-printing in the jupyter cell "magic", so jupyter notebook cells have readable STIX JSON again
