### PR TITLE
fix syntax error detected by python3.9, missing space after assert

### DIFF
--- a/stix2generator/test/test_proto.py
+++ b/stix2generator/test/test_proto.py
@@ -177,7 +177,7 @@ def test_basic(processor):
     assert len(objs) == 1
 
     identity = objs[0]
-    assert(identity.type == "identity")
+    assert identity.type == "identity"
 
 
 def test_basic_count(processor):


### PR DESCRIPTION
Fixes issue #37 