### PR TITLE
Fix "KeyError: 'required'" bug in _update_dict_recursive() in tests

### DIFF
--- a/stix2generator/__init__.py
+++ b/stix2generator/__init__.py
@@ -130,11 +130,11 @@ def _update_dict_recursive(base_dict, new_dict):
     for key, val in new_dict.items():
         if isinstance(val, Mapping):
             # if new val is empty, that means delete key
-            if not val:
+            if not val and key in base_dict:
                 del base_dict[key]
             else:
                 base_dict[key] = _update_dict_recursive(base_dict.get(key, {}), val)
-        elif isinstance(val, list):
+        elif isinstance(val, list) and key in base_dict:
             base_dict[key].extend(val)
         else:
             base_dict[key] = val

--- a/stix2generator/language/build_stix.py
+++ b/stix2generator/language/build_stix.py
@@ -50,7 +50,9 @@ def parse_args():
                             """
                             )
     arg_parser.add_argument("--interop",
-                            help="""Specifies to use a custorm interop registry so content mirrors valid interop content. Warning, overwrites extra-specs if both called.
+                            help="""Specifies to use a custorm interop registry
+                            so content mirrors valid interop content. Warning,
+                            overwrites extra-specs if both called.
                             """,
                             action="store_true")
     arg_parser.add_argument("-n", "--embed-variable-names",
@@ -82,7 +84,7 @@ def main():
     if args.extra_specs:
         with open(args.extra_specs, "r", encoding=args.encoding) as f:
             extra_specs = json.load(f)
-    if args.interop: 
+    if args.interop:
         with open('../interop_custom.json', "r", encoding=args.encoding) as f:
             extra_specs = json.load(f)
     tmp_config = {}

--- a/stix2generator/test/test_proto.py
+++ b/stix2generator/test/test_proto.py
@@ -177,7 +177,7 @@ def test_basic(processor):
     assert len(objs) == 1
 
     identity = objs[0]
-    assert(identity.type == "identity")
+    assert identity.type == "identity"
 
 
 def test_basic_count(processor):


### PR DESCRIPTION
Should let tests pass again.