### PR TITLE
Fix reference graph generator's "halt" generator to inherit customizations

### DIFF
--- a/stix2generator/generation/object_generator.py
+++ b/stix2generator/generation/object_generator.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import logging
 import math
@@ -106,8 +107,8 @@ class ObjectGenerator:
 
         :param spec_registry: A name->specification mapping used to look
             up references inside of specifications
-        :param semantic_providers: A list of semantic providers (e.g.
-            instances of subclasses of SemanticsProvider)
+        :param semantic_providers: An iterable of semantic providers (e.g.
+            instances of subclasses of SemanticsProvider), or None
         :param config: A Config instance giving user settings regarding
             generation.  If None, defaults will be used.
         """
@@ -141,6 +142,27 @@ class ObjectGenerator:
         :return: An iterable of spec names
         """
         return self.__specs.keys()
+
+    def derive_generator(self, new_config):
+        """
+        Create an object generator using this generator's registry and
+        semantics providers, but with a given config.
+
+        :param new_config: An instance of Config giving desired configuration
+            settings for the new object generator
+        :return: A new object generator
+        """
+
+        our_providers = copy.deepcopy(set(self.__semantics.values()))
+        our_specs = copy.deepcopy(self.__specs)
+
+        new_generator = ObjectGenerator(
+            spec_registry=our_specs,
+            semantic_providers=our_providers,
+            config=new_config
+        )
+
+        return new_generator
 
     def generate(
         self, spec_name, expected_type=None, spec_name_stack=None,

--- a/stix2generator/generation/reference_graph_generator.py
+++ b/stix2generator/generation/reference_graph_generator.py
@@ -515,7 +515,7 @@ class ReferenceGraphGenerator:
             .Config(
                 **halt_generator_config_dict
             )
-        self.__halt_generator = stix2generator.create_object_generator(
+        self.__halt_generator = object_generator.derive_generator(
             halt_generator_config
         )
 


### PR DESCRIPTION
Fixes #50 .

This fix adds a method to ObjectGenerator named `derive_generator()`, which enables callers to create one object generator based on another.  It presently allows you to override the config settings in the "derived" object generator, but not the spec registry or semantics providers (which get carried over unchanged).  ReferenceGraphGenerator uses this method to create its "halt" generator.  This is sufficient to fix the issue.

Also added a unit test which triggered the bug originally, and now passes.